### PR TITLE
Minor tweaks for latest dart

### DIFF
--- a/flutter_google_street_view/lib/flutter_google_street_view_web.dart
+++ b/flutter_google_street_view/lib/flutter_google_street_view_web.dart
@@ -12,5 +12,6 @@ import 'package:google_maps/google_maps.dart' as gmaps;
 import 'package:google_maps/google_maps.dart';
 import 'package:kotlin_scope_function/kotlin_scope_function.dart';
 import 'package:flutter_google_street_view/src/web/shims/dart_ui.dart' as ui;
+import 'dart:ui_web' as uiWeb;
 
 part 'package:flutter_google_street_view/src/web/plugin.dart';

--- a/flutter_google_street_view/lib/src/web/plugin.dart
+++ b/flutter_google_street_view/lib/src/web/plugin.dart
@@ -138,12 +138,9 @@ class FlutterGoogleStreetViewPlugin {
       ..style.height = '100%';
     _divs[_viewId] = _div;
     _plugins[_viewId] ??= this;
-    ui.platformViewRegistry.registerViewFactory(
+    uiWeb.platformViewRegistry.registerViewFactory(
       _getViewType(_viewId),
-      (int viewId) => HtmlElement.new()
-        ..id = _div.id
-        ..style.width = _div.style.width
-        ..style.height = _div.style.height,
+      (int viewId) => _div,
     );
     _setup(arg);
     _methodChannel = MethodChannel(


### PR DESCRIPTION
`HtmlElement.new()` was throwing with latest dart, so I reverted this change and fixed the warning for the `platformViewRegistry` getter.